### PR TITLE
stored path with validation

### DIFF
--- a/src/components.rs
+++ b/src/components.rs
@@ -1,7 +1,5 @@
 use crate::events::{Action, PlayerAction};
 use bevy::prelude::*;
-use petgraph::visit::EdgeRef;
-use petgraph::{graph::NodeIndex, graphmap::UnGraphMap};
 use rustc_hash::FxHashMap;
 
 // Label components
@@ -39,13 +37,18 @@ pub struct CastTimer(pub Timer);
 pub struct CooldownTimer(pub Timer);
 
 #[derive(PartialEq, Clone, Copy)]
-pub struct MouseCoords(pub Vec3);
+pub struct Coords(pub Vec3);
 
 #[derive(PartialEq)]
 pub enum CharState {
-    Casting((CastAbility, MouseCoords)),
-    Moving(MouseCoords),
-    Channeling((ChannelAbility, MouseCoords)),
+    Casting((CastAbility, Coords)),
+
+    // Coords marks the targeted destination of the
+    // unit (player or mob) and if the pathing system
+    // has run its path is saved in the vec with
+    // move-tile coords.
+    Moving(Coords, Option<std::collections::VecDeque<(i32, i32)>>),
+    Channeling((ChannelAbility, Coords)),
     Idle,
 }
 
@@ -53,7 +56,7 @@ impl CharState {
     pub fn can_cast(&self) -> bool {
         match self {
             Self::Casting(_) => false,
-            Self::Moving(_) => true,
+            Self::Moving(..) => true,
             Self::Channeling(_) => true,
             Self::Idle => true,
         }
@@ -62,7 +65,7 @@ impl CharState {
     pub fn can_move(&self) -> bool {
         match self {
             Self::Casting(_) => false,
-            Self::Moving(_) => true,
+            Self::Moving(..) => true,
             Self::Channeling(_) => false,
             Self::Idle => true,
         }
@@ -72,12 +75,10 @@ impl CharState {
 impl From<PlayerAction> for CharState {
     fn from(action: PlayerAction) -> Self {
         match action.action {
-            Action::Move => CharState::Moving(MouseCoords(action.mouse_coords)),
-            Action::Cast(ability) => {
-                CharState::Casting((ability, MouseCoords(action.mouse_coords)))
-            }
+            Action::Move => CharState::Moving(Coords(action.mouse_coords), None),
+            Action::Cast(ability) => CharState::Casting((ability, Coords(action.mouse_coords))),
             Action::Channel(ability) => {
-                CharState::Channeling((ability, MouseCoords(action.mouse_coords)))
+                CharState::Channeling((ability, Coords(action.mouse_coords)))
             }
         }
     }
@@ -100,81 +101,5 @@ impl UserControls {
         keyboard.insert(KeyCode::E, Action::Channel(ChannelAbility::Lazer));
 
         Self { mouse, keyboard }
-    }
-}
-
-pub struct TileGraph {
-    graph: UnGraphMap<(i32, i32), ()>,
-    map_size: i32,
-    cell_size: f32,
-}
-
-impl TileGraph {
-    pub fn new(map_size: i32, cell_size: f32) -> Self {
-        let mut graph = UnGraphMap::new();
-
-        for x in -map_size..=map_size {
-            for y in -map_size..=map_size {
-                graph.add_node((x, y));
-            }
-        }
-
-        let nodes: Vec<(i32, i32)> = graph.nodes().collect();
-        for (x, y) in nodes {
-            if x != map_size {
-                graph.add_edge((x, y), (x + 1, y), ());
-            }
-            if y != -map_size {
-                graph.add_edge((x, y), (x, y + 1), ());
-            }
-            if x != map_size && y != -map_size {
-                graph.add_edge((x, y), (x + 1, y + 1), ());
-            }
-            if x != -map_size && y != -map_size {
-                graph.add_edge((x, y), (x - 1, y - 1), ());
-            }
-        }
-        Self {
-            graph,
-            map_size,
-            cell_size,
-        }
-    }
-
-    fn get_index(&self, x: f32, y: f32) -> (i32, i32) {
-        let x = (x / self.cell_size).round() as i32;
-        let y = (y / self.cell_size).round() as i32;
-        (x, y)
-    }
-    pub fn path(&self, start: (f32, f32), end: (f32, f32), blocked: &Vec<Vec3>) -> Option<Vec3> {
-        let blocked: std::collections::HashSet<(i32, i32)> = blocked
-            .iter()
-            .map(|translation| self.get_index(translation.x, translation.y))
-            .collect();
-
-        let end = self.get_index(end.0, end.1);
-        if let Some((_, path)) = petgraph::algo::astar(
-            &self.graph,
-            self.get_index(start.0, start.1),
-            |target| target == end,
-            |(_, (e0, e1), _)| {
-                if blocked.contains(&(e0, e1)) {
-                    i32::MAX
-                } else {
-                    (e0 - end.0).pow(2) + (e1 - end.1).pow(2)
-                }
-            },
-            |_| 0,
-        ) {
-            println!("{:?}", path);
-            if path.len() > 1 {
-                return Some(Vec3::new(
-                    path[1].0 as f32 * self.cell_size,
-                    path[1].1 as f32 * self.cell_size,
-                    1.0,
-                ));
-            }
-        }
-        None
     }
 }

--- a/src/systems/abilities.rs
+++ b/src/systems/abilities.rs
@@ -1,5 +1,4 @@
 use crate::components::*;
-use crate::events::*;
 use bevy::prelude::*;
 
 pub fn charges_cooldown_system(
@@ -39,7 +38,7 @@ pub fn dash(
                     // if we don't have any charges then we cannot cast, so just
                     // keep moving towards the dash location
                     if dash_charges.0 == 0 {
-                        *state = CharState::Moving(ability.1);
+                        *state = CharState::Moving(ability.1, None);
                     // if the cast timer is paused then we need to start casting
                     } else if cast_timer.0.paused() && dash_charges.0 > 0 {
                         dash_charges.0 -= 1;
@@ -62,7 +61,7 @@ pub fn dash(
                             transform.translation += dash_range * direction.normalize();
                         }
                         // keep moving toward dash destination
-                        *state = CharState::Moving(ability.1);
+                        *state = CharState::Moving(ability.1, None);
                     // if the cast timer is running and not finished then continue
                     } else {
                         cast_timer.0.tick(time.delta());

--- a/src/systems/movement.rs
+++ b/src/systems/movement.rs
@@ -1,27 +1,182 @@
-use crate::components::*;
+use crate::components::{CharState, MovementSpeed};
 use bevy::prelude::*;
+use petgraph::graphmap::UnGraphMap;
+use std::collections::VecDeque;
+
 /// System that moves the player and mobs. For anything that has
 /// the `Moving` state, update their position based on their speed.
+///
+/// Uses the TileGraph struct to calculate paths if needed. If a
+/// path exists, this system also validates that path before moving.
+///
+/// Because this system moves units it creates and maintains a data
+/// structure to track which tiles are impassable for the pathing
+/// function.
 pub fn movement_system(
     time: Res<Time>,
     mut query: Query<(&mut CharState, &MovementSpeed, &mut Transform)>,
-    q_graph: Query<&TileGraph>,
+    mut q_graph: Query<&mut TileGraph>,
 ) {
     let delta_seconds = time.delta_seconds();
-    for (mut state, speed, mut transform) in query.iter_mut() {
-        if let CharState::Moving(destination) = *state {
-            if let Ok(graph) = q_graph.single() {
-                if let Some(destination) = graph.path(
-                    (transform.translation.x, transform.translation.y),
-                    (destination.0.x, destination.0.y),
-                    &vec![],
-                ) {
-                    let direction = destination - transform.translation;
-                    transform.translation += speed.0 * delta_seconds * direction.normalize();
-                } else {
-                    *state = CharState::Idle;
+    if let Ok(mut graph) = q_graph.single_mut() {
+        for (mut state, speed, mut transform) in query.iter_mut() {
+            match *state {
+                // units that have entered moving state but no path
+                // has been calculated yet
+                CharState::Moving(destination, None) => {
+                    if let Some(path) = graph.path(
+                        (transform.translation.x, transform.translation.y),
+                        (destination.0.x, destination.0.y),
+                    ) {
+                        // update the state to have the path we chose
+                        *state = CharState::Moving(destination, Some(path));
+                        move_char(
+                            &mut graph,
+                            &mut transform,
+                            speed.0,
+                            delta_seconds,
+                            &mut state,
+                        );
+                    } else {
+                        *state = CharState::Idle;
+                    }
                 }
+                // units that already have a path
+                CharState::Moving(destination, Some(_)) => {
+                    // check if our current path is valid otherwise get a new one
+                    if !graph.validate(&mut state) {
+                        if let Some(path) = graph.path(
+                            (transform.translation.x, transform.translation.y),
+                            (destination.0.x, destination.0.y),
+                        ) {
+                            *state = CharState::Moving(destination, Some(path));
+                        } else {
+                            *state = CharState::Idle;
+                        }
+                    }
+
+                    move_char(
+                        &mut graph,
+                        &mut transform,
+                        speed.0,
+                        delta_seconds,
+                        &mut state,
+                    );
+                }
+                // all other character states can be ignored.
+                // potential optimazation could be to alter
+                // the query so it only selects characters with
+                // the correct state
+                _ => (),
             }
+        }
+    }
+}
+
+fn move_char(
+    tiles: &mut TileGraph,
+    char_transform: &mut Transform,
+    move_speed: f32,
+    delta_seconds: f32,
+    char_state: &mut CharState,
+) {
+    if let CharState::Moving(_, Some(path)) = char_state {
+        if let Some(path_step) = path.front() {
+            let direction = tiles.get_coords(path_step.0, path_step.1) - char_transform.translation;
+            char_transform.translation += move_speed * delta_seconds * direction.normalize();
+            let new_x = char_transform.translation.x;
+            let new_y = char_transform.translation.y;
+
+            if tiles.get_index(new_x, new_y) == *path_step {
+                path.pop_front();
+            }
+        } else {
+            *char_state = CharState::Idle;
+        }
+    }
+}
+
+pub struct TileGraph {
+    graph: UnGraphMap<(i32, i32), ()>,
+    occupied_tiles: std::collections::HashSet<(i32, i32)>,
+    map_size: i32,
+    cell_size: f32,
+}
+
+impl TileGraph {
+    pub fn new(map_size: i32, cell_size: f32) -> Self {
+        let mut graph = UnGraphMap::new();
+        let occupied_tiles = std::collections::HashSet::new();
+
+        for x in -map_size..=map_size {
+            for y in -map_size..=map_size {
+                graph.add_node((x, y));
+            }
+        }
+
+        let nodes: Vec<(i32, i32)> = graph.nodes().collect();
+        for (x, y) in nodes {
+            if x != map_size {
+                graph.add_edge((x, y), (x + 1, y), ());
+            }
+            if y != -map_size {
+                graph.add_edge((x, y), (x, y + 1), ());
+            }
+            if x != map_size && y != -map_size {
+                graph.add_edge((x, y), (x + 1, y + 1), ());
+            }
+            if x != -map_size && y != -map_size {
+                graph.add_edge((x, y), (x - 1, y - 1), ());
+            }
+        }
+        Self {
+            graph,
+            occupied_tiles,
+            map_size,
+            cell_size,
+        }
+    }
+
+    pub fn get_index(&self, x: f32, y: f32) -> (i32, i32) {
+        let x = (x / self.cell_size).round() as i32;
+        let y = (y / self.cell_size).round() as i32;
+        (x, y)
+    }
+
+    pub fn get_coords(&self, x: i32, y: i32) -> Vec3 {
+        Vec3::new(x as f32 * self.cell_size, y as f32 * self.cell_size, 1.0)
+    }
+
+    pub fn path(&self, start: (f32, f32), end: (f32, f32)) -> Option<VecDeque<(i32, i32)>> {
+        let end = self.get_index(end.0, end.1);
+        if let Some((_, path)) = petgraph::algo::astar(
+            &self.graph,
+            self.get_index(start.0, start.1),
+            |target| target == end,
+            |(_, (e0, e1), _)| {
+                if self.occupied_tiles.contains(&(e0, e1)) {
+                    i32::MAX
+                } else {
+                    (e0 - end.0).pow(2) + (e1 - end.1).pow(2)
+                }
+            },
+            |_| 0,
+        ) {
+            Some(path.into_iter().skip(1).collect())
+        } else {
+            // TODO: Pathing note --- if there is no valid path then a* fails
+            // Right now we just return None when this happens but it would
+            // be better if the path that resulted in the closest endpoint
+            // to the desired location was produced.
+            None
+        }
+    }
+
+    pub fn validate(&self, char_state: &mut CharState) -> bool {
+        if let CharState::Moving(_, Some(path)) = char_state {
+            path.iter().all(|step| !self.occupied_tiles.contains(step))
+        } else {
+            false
         }
     }
 }

--- a/src/systems/setup.rs
+++ b/src/systems/setup.rs
@@ -51,6 +51,6 @@ pub fn setup_system(
         }
     }
 
-    let graph = TileGraph::new(map_size, cell_size);
+    let graph = crate::systems::movement::TileGraph::new(map_size, cell_size);
     commands.spawn().insert(graph);
 }


### PR DESCRIPTION
Changes:
- pathing algorithm only runs once at the start of a movement and is saved with the character
- paths get validated before a unit moves every system cycle
- if a path is invalid it is recalculated

Currently to validate the paths it is checking each step with an empty hashset with the occupied move tiles. The movement system will maintain this hashset but currently does not.