### PR TITLE
movement system tracks unit locations

### DIFF
--- a/src/systems/player_action.rs
+++ b/src/systems/player_action.rs
@@ -15,6 +15,15 @@ pub fn player_action_system(
             match player_action.action {
                 Action::Move => {
                     if state.can_move() {
+                        if let CharState::Moving(destination, _) = *state {
+                            // if our movement action is close to the current movement command then
+                            // don't update and use old path. This fixes a bug where if the move
+                            // command is held in one spot the paths chosen can flip back and forth
+                            // locking the player in place
+                            if (destination.0 - player_action.mouse_coords).length() < 50.0 {
+                                return;
+                            }
+                        }
                         *state = CharState::from(*player_action)
                     }
                 }

--- a/src/systems/setup.rs
+++ b/src/systems/setup.rs
@@ -40,14 +40,17 @@ pub fn setup_system(
             let x = start_x + (x as f32 * cell_size);
             let y = start_y - (y as f32 * cell_size);
 
-            commands
-                .spawn_bundle(GeometryBuilder::build_as(
-                    &cell,
-                    color,
-                    drawmode,
-                    Transform::from_xyz(x, y, 0.0),
-                ))
-                .insert(Cell);
+            // make an obstacle to path around
+            if (Vec2::new(-150.0, -150.0) - Vec2::new(x, y)).length() > 80.0 {
+                commands
+                    .spawn_bundle(GeometryBuilder::build_as(
+                        &cell,
+                        color,
+                        drawmode,
+                        Transform::from_xyz(x, y, 0.0),
+                    ))
+                    .insert(Cell);
+            }
         }
     }
 


### PR DESCRIPTION
Movement system now updates the TileGraph with the locations of moving units. When units are created and destroyed their position data should be added to the TileGraph for the movement system to update.